### PR TITLE
Add an option to ensure all test-cases work the same

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from typing import Any, Optional
+
+import attrs
 import pytest
 
 
@@ -8,3 +11,59 @@ import pytest
 )
 def set_of_range(request):
     yield set(range(request.param))
+
+
+@attrs.define
+class TestResult:
+    nodeid: Optional[str] = None
+    result: Any = attrs.field(default=None, repr=False)
+
+    def __bool__(self):
+        return self.nodeid is not None
+
+
+@pytest.fixture(scope="class")
+def saved_result():
+    return TestResult()
+
+
+@pytest.fixture
+def benchmark_and_verify(request, saved_result, benchmark):
+    class Benchmark:
+        def _check_result(self, function_to_benchmark, *args, **kwargs):
+            result = function_to_benchmark(*args, **kwargs)
+            nodeid = request.node.nodeid
+            if saved_result and saved_result.result != result:
+                pytest.fail(reason=f"Result different from {saved_result.nodeid}")
+                return
+            saved_result.result = result
+            saved_result.nodeid = nodeid
+
+        def __call__(self, function_to_benchmark, *args, **kwargs):
+            self._check_result(function_to_benchmark, *args, **kwargs)
+
+            return benchmark(function_to_benchmark, *args, **kwargs)
+
+        def pedantic(
+            self,
+            target,
+            args=(),
+            kwargs=None,
+            setup=None,
+            rounds=1,
+            warmup_rounds=0,
+            iterations=1,
+        ):
+            self._check_result(target, *args, **(kwargs or {}))
+
+            return benchmark.pedantic(
+                target=target,
+                args=args,
+                kwargs=kwargs,
+                setup=setup,
+                rounds=rounds,
+                warmup_rounds=warmup_rounds,
+                iterations=iterations,
+            )
+
+    return Benchmark()

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,4 +1,7 @@
-class TestDictLiteralCreation:
+from tests.utils import Verify
+
+
+class TestDictLiteralCreation(Verify):
     """Compare different methods of creating a dict literal"""
 
     def test_literal(self, benchmark):
@@ -18,7 +21,7 @@ class TestDictLiteralCreation:
         benchmark(run)
 
 
-class TestDictComprehension:
+class TestDictComprehension(Verify):
     """Compare different comprehensions for dict creation"""
 
     VALUES = list(range(100000))

--- a/tests/test_set_union.py
+++ b/tests/test_set_union.py
@@ -1,7 +1,8 @@
 import itertools
+from tests.utils import Verify
 
 
-class TestSetUnion:
+class TestSetUnion(Verify):
     """
     Test the performance of different ways to unify multiple sets.
     """

--- a/tests/test_slice_string.py
+++ b/tests/test_slice_string.py
@@ -1,8 +1,10 @@
 import operator
 import re
 
+from tests.utils import Verify
 
-class TestPairs3:
+
+class TestPairs3(Verify):
     """
     Try and optimiza splitting a 6-character string into a tuple
     of 3 2-character strings.

--- a/tests/test_tuple_creation.py
+++ b/tests/test_tuple_creation.py
@@ -1,0 +1,25 @@
+from tests.utils import Verify
+
+
+class TestTupleComprehension(Verify):
+    """
+    Compare various ways to write "tuple comprehensions"
+    """
+
+    DATA = list(range(1000000))
+
+    def test_generator_comprehension(self, benchmark):
+        """tuple from generator comprehension"""
+
+        def run(data):
+            return tuple(x for x in data)
+
+        benchmark(run, self.DATA)
+
+    def test_list_comprehension(self, benchmark):
+        """tuple from list comprehension"""
+
+        def run(data):
+            return tuple([x for x in data])
+
+        benchmark(run, self.DATA)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+class Verify:
+    @pytest.fixture
+    def benchmark(self, benchmark_and_verify):
+        return benchmark_and_verify


### PR DESCRIPTION
We store the result of the first run of the first test-case for every class, then compare against it. This allows us to detect bugs in the benchmarks.